### PR TITLE
time interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A `DateInterval` object. You'll need to set the [format](http://php.net/manual/e
 ```twig
 {% set time = readTime(entry) %}
 
-{{ time.interval('%h hours, %i minutes, $s seconds') }}
+{{ time.interval('%h hours, %i minutes, %s seconds') }}
 ```
 
 #### `seconds`


### PR DESCRIPTION
Changed time interval to {{ time.interval('%h hours, %i minutes, %s seconds') }}
The s had $ sign behind it